### PR TITLE
fix(manager): disable `exp_name` containing '/'

### DIFF
--- a/mltemplate/utils/data_utils.py
+++ b/mltemplate/utils/data_utils.py
@@ -1,11 +1,11 @@
 from pathlib import Path
 from typing import Optional
 
-from rich.progress import track
-
 
 def local_iter(start: int, end: int, step: int, local_rank: Optional[int] = None, desc: Optional[str] = None):
     if local_rank == 0:
+        from rich.progress import track
+
         return track(range(start, end, step), description=desc or "Working...")
     else:
         return range(start, end, step)

--- a/mltemplate/utils/data_utils.py
+++ b/mltemplate/utils/data_utils.py
@@ -11,7 +11,8 @@ def local_iter(start: int, end: int, step: int, local_rank: Optional[int] = None
         return range(start, end, step)
 
 
-def valid_dir(dir_path: Path):
-    result = dir_path.expanduser().absolute()
-    result.mkdir(parents=True, exist_ok=True)
+def valid_dir(dir_path: Path | str, do_mkdir=True):
+    result = Path(dir_path).expanduser().absolute()
+    if do_mkdir:
+        result.mkdir(parents=True, exist_ok=True)
     return result

--- a/mltemplate/utils/manager.py
+++ b/mltemplate/utils/manager.py
@@ -34,14 +34,8 @@ parser.add_argument("--cfg_dir", default="configs", type=str)
 parser.add_argument("--cfg_help", action="store_true", help="Show config and exit.")
 parser.add_argument("--test", action="store_true", dest="test", default=False)
 parser.add_argument("--local_rank", type=int, default=0, help="GPU local rank.")
-parser.add_argument(
-    "-l",
-    "--log",
-    type=str,
-    default=LOG_LEVELS.WARN.name.lower(),
-    choices=[e.name.lower() for e in list(LOG_LEVELS)],
-    help="Set logging level.",
-)
+parser.add_argument("-l", "--log", type=str, default=LOG_LEVELS.WARN.name.lower(),
+                    choices=[e.name.lower() for e in list(LOG_LEVELS)], help="Set logging level.")  # fmt: skip
 parser.add_argument("--log_file", type=str, default="", help="If set, logging will be output to file.")
 parser.add_argument("--log_overwrite", action="store_true", help="Will overwrite log file from the beginning.")
 parser.add_argument("-v", "--verbose", action="store_true", help="Shorthand for `--debug=info`.")


### PR DESCRIPTION
The code does not work when `exp_name` contains '/'.

This PR simply assert checks and aborts with error message when `exp_name` contains invalid letters.

### Notes

Other linting refactors added as well.